### PR TITLE
feat: scaling schedules

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,18 @@ variable "shielded_instance_config" {
   }
 }
 
+variable "schedules" {
+  description = "Only deploy instances during certain time windows. Schedule follows the extended cron format, and time_zone must be a time zone name from the tz database"
+  type = list(object({
+    name         = string
+    description  = string
+    schedule     = string
+    time_zone    = string
+    duration_sec = number
+  }))
+  default = null
+}
+
 variable "domain" {
   type        = string
   description = "Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://`"


### PR DESCRIPTION
## what

- Give users the option to attach scaling schedules to the MIG
- Note that the schedules' `min_required_replicas` is not exposed as a variable, and is always set to `1`.

## why

- Many times, teams only use Atlantis during certain periods of the day (e.g. 8AM to 7PM), and this feature allows the MIG to scale down to zero outside the defined periods.
- This also doubles as a cost-saving mechanism, which is often the main concern of using Atlantis vs GitHub Actions, for example.

## references
* Scaling Schedules - https://cloud.google.com/compute/docs/autoscaler/scaling-schedules#concepts
