### PR TITLE
revert: scaling schedules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -279,8 +279,7 @@ resource "google_compute_instance_group_manager" "default" {
     initial_delay_sec = 30
   }
 
-  # We cannot set target_size when using an autoscaler
-  target_size = var.schedules == null ? 1 : 0
+  target_size = 1
 
   update_policy {
     type                           = "PROACTIVE"
@@ -292,32 +291,6 @@ resource "google_compute_instance_group_manager" "default" {
   }
   project  = var.project
   provider = google-beta
-}
-
-resource "google_compute_autoscaler" "default" {
-  count = var.schedules == null ? 0 : 1
-
-  name   = var.name
-  zone   = var.zone
-  target = google_compute_instance_group_manager.default.id
-
-  autoscaling_policy {
-    max_replicas    = 1 # Allow at most one instance
-    min_replicas    = 0 # Allow scaling down to zero instances
-    cooldown_period = 60
-
-    dynamic "scaling_schedules" {
-      for_each = var.schedules
-      content {
-        name                  = scaling_schedules.value.name
-        description           = scaling_schedules.value.description
-        min_required_replicas = 1
-        schedule              = scaling_schedules.value.schedule
-        time_zone             = scaling_schedules.value.time_zone
-        duration_sec          = scaling_schedules.value.duration_sec
-      }
-    }
-  }
 }
 
 resource "google_compute_global_address" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -108,18 +108,6 @@ variable "shielded_instance_config" {
   }
 }
 
-variable "schedules" {
-  description = "Only deploy instances during certain time windows. Schedule follows the extended cron format, and time_zone must be a time zone name from the tz database"
-  type = list(object({
-    name         = string
-    description  = string
-    schedule     = string
-    time_zone    = string
-    duration_sec = number
-  }))
-  default = null
-}
-
 variable "domain" {
   type        = string
   description = "Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://`"


### PR DESCRIPTION

- We cannot use an autoscaler with stateful managed instance groups.