### PR TITLE
feat!: scaling schedules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,24 +172,10 @@ resource "google_compute_instance_template" "default" {
 
   #  Persistent disk for Atlantis
   disk {
-    device_name  = "atlantis-disk-0"
-    disk_type    = "pd-ssd"
-    mode         = "READ_WRITE"
-    disk_size_gb = var.persistent_disk_size_gb
-    auto_delete  = false
-    labels = merge(
-      local.atlantis_labels,
-      {
-        "disk-type" = "data"
-      },
-    )
-
-    dynamic "disk_encryption_key" {
-      for_each = var.disk_kms_key_self_link != null ? [1] : []
-      content {
-        kms_key_self_link = var.disk_kms_key_self_link
-      }
-    }
+    device_name = "atlantis-disk-0"
+    mode        = "READ_WRITE"
+    source      = google_compute_disk.persistent.name
+    auto_delete = false
   }
 
   network_interface {
@@ -221,6 +207,27 @@ resource "google_compute_instance_template" "default" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "google_compute_disk" "persistent" {
+  name = var.name
+  type = "pd-ssd"
+  size = var.persistent_disk_size_gb
+  zone = var.zone
+  labels = merge(
+    local.atlantis_labels,
+    {
+      "disk-type" = "data"
+    },
+  )
+
+  dynamic "disk_encryption_key" {
+    for_each = var.disk_kms_key_self_link != null ? [1] : []
+    content {
+      kms_key_self_link = var.disk_kms_key_self_link
+    }
+  }
+
 }
 
 resource "google_compute_health_check" "default" {
@@ -269,17 +276,13 @@ resource "google_compute_instance_group_manager" "default" {
     port = local.atlantis_port
   }
 
-  stateful_disk {
-    device_name = "atlantis-disk-0"
-    delete_rule = "NEVER"
-  }
-
   auto_healing_policies {
     health_check      = google_compute_health_check.default_instance_group_manager.id
     initial_delay_sec = 30
   }
 
-  target_size = 1
+  # We cannot set target_size when using an autoscaler
+  target_size = var.schedules == null ? 1 : null
 
   update_policy {
     type                           = "PROACTIVE"
@@ -291,6 +294,32 @@ resource "google_compute_instance_group_manager" "default" {
   }
   project  = var.project
   provider = google-beta
+}
+
+resource "google_compute_autoscaler" "default" {
+  count = var.schedules == null ? 0 : 1
+
+  name   = var.name
+  zone   = var.zone
+  target = google_compute_instance_group_manager.default.id
+
+  autoscaling_policy {
+    max_replicas    = 1 # Allow at most one instance
+    min_replicas    = 0 # Allow scaling down to zero
+    cooldown_period = 60
+
+    dynamic "scaling_schedules" {
+      for_each = var.schedules
+      content {
+        name                  = scaling_schedules.value.name
+        description           = scaling_schedules.value.description
+        min_required_replicas = 1
+        schedule              = scaling_schedules.value.schedule
+        time_zone             = scaling_schedules.value.time_zone
+        duration_sec          = scaling_schedules.value.duration_sec
+      }
+    }
+  }
 }
 
 resource "google_compute_global_address" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,23 @@ variable "shielded_instance_config" {
   }
 }
 
+variable "schedules" {
+  description = "Only deploy instances during certain time windows. Schedule follows the extended cron format, and time_zone must be a time zone name from the tz database"
+  type = list(object({
+    name                  = string
+    description           = string
+    min_required_replicas = number
+    schedule              = string
+    time_zone             = string
+    duration_sec          = number
+  }))
+  default = null
+  validation {
+    condition     = alltrue([for s in var.schedules : s.min_required_replicas == 0 || s.min_required_replicas == 1])
+    error_message = "min_required_replicas must be exactly 0 or 1"
+  }
+}
+
 variable "domain" {
   type        = string
   description = "Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://`"


### PR DESCRIPTION
## what

- Give users the option to attach scaling schedules to the MIG
- Note that the schedules' `min_required_replicas` is limited to the values `0` and `1`
- The 50GB stateful disk is no longer created by the mig, which makes the mig no longer stateful.
  - This was required because we can only attach autoscalers to regular (stateless) migs.
  - The disk is created in a new resource, and referenced in the instance template.
  - This also means the disk will be destroyed when `terraform destroy` runs, instead of leaving the disk behind.

## why

- Many times, teams only use Atlantis during certain periods of the day (e.g. 8AM to 7PM), and this feature allows the MIG to scale down to zero outside the defined periods.
- This also doubles as a cost-saving mechanism, which is often the main concern of using Atlantis vs GitHub Actions, for example.

## references

* Scaling Schedules - https://cloud.google.com/compute/docs/autoscaler/scaling-schedules#concepts
