### PR TITLE
feat: add variable to enable autoupdate

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -214,6 +214,13 @@ variable "enable_confidential_vm" {
   default     = false
 }
 
+variable "enable_autoupdate" {
+  type        = bool
+  description = "Enable automatic updates for the OS and installed packages | https://cloud.google.com/container-optimized-os/docs/concepts/auto-update#disable_automatic_updates"
+  default     = null # use a null value to not set the metadata key
+}
+
+
 variable "shared_vpc" {
   description = "Whether to deploy within a shared VPC"
   type = object({


### PR DESCRIPTION
## what
-   Introduced a new variable `enable_autoupdate` to control automatic updates for OS and installed packages.
-   Updated `main.tf` to conditionally include the `cos-update-strategy` metadata based on the value of `enable_autoupdate`.
-   Modified `google_compute_instance_template` resource to merge the new `update_strategy_metadata` with existing metadata.

## why
-   The addition of `enable_autoupdate` provides flexibility in managing automatic updates, allowing users to enable or disable this feature as needed.
-   Conditional inclusion of the `cos-update-strategy` metadata prevents unnecessary changes to past deployments, ensuring backward compatibility and stability.
-   Merging `update_strategy_metadata` with existing metadata ensures that the update strategy is applied only when necessary, reducing configuration complexity and potential errors.

## references
- For more information on automatic updates, refer to the [Google Cloud documentation](https://cloud.google.com/container-optimized-os/docs/concepts/auto-update#disable_automatic_updates).
