### PR TITLE
Add validation to autoscaling variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,10 @@ variable "autoscaling" {
     }))
   })
   default = null
+  validation {
+    condition     = var.schedules != null ? length(var.schedules) > 0 : true
+    error_message = "If this variable is defined, at least one schedule must be provided"
+  }
 }
 
 variable "domain" {


### PR DESCRIPTION
## what
* Add validation to autoscaling variable

## why
* To prevent users from creating an autoscaling policy with no schedules.
* When a policy is created with no schedules, Google creates a scaling signal based on CPU usage, that is not destroyed when a schedule is created.
* This CPU signal prevents the scaler from destroying the last (and only) VM.
