### PR TITLE
feat: add option to expose /healthz without IAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | <a name="input_enable_confidential_vm"></a> [enable\_confidential\_vm](#input\_enable\_confidential\_vm) | Enable Confidential VM. If true, on host maintenance will be set to TERMINATE | `bool` | `false` | no |
 | <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables OS Login service on the VM | `bool` | `false` | no |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Key-value pairs representing environment variables and their respective values | `map(any)` | n/a | yes |
+| <a name="input_expose_healthz_publicly"></a> [expose\_healthz\_publicly](#input\_expose\_healthz\_publicly) | Exposes the /healthz endpoint publicly even if Atlantis is protected by IAP | `bool` | `false` | no |
 | <a name="input_expose_metrics_publicly"></a> [expose\_metrics\_publicly](#input\_expose\_metrics\_publicly) | Exposes the /metrics endpoint publicly even if Atlantis is protected by IAP | `bool` | `false` | no |
 | <a name="input_google_logging_enabled"></a> [google\_logging\_enabled](#input\_google\_logging\_enabled) | Enable Google Cloud Logging | `bool` | `true` | no |
 | <a name="input_google_logging_use_fluentbit"></a> [google\_logging\_use\_fluentbit](#input\_google\_logging\_use\_fluentbit) | Enable Google Cloud Logging using Fluent Bit | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -443,6 +443,14 @@ resource "google_compute_url_map" "default" {
           service = google_compute_backend_service.default.id
         }
       }
+
+      dynamic "path_rule" {
+        for_each = var.expose_healthz_publicly ? [1] : []
+        content {
+          paths   = ["/healthz"]
+          service = google_compute_backend_service.default.id
+        }
+      }
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -172,6 +172,12 @@ variable "expose_metrics_publicly" {
   default     = false
 }
 
+variable "expose_healthz_publicly" {
+  type        = bool
+  description = "Exposes the /healthz endpoint publicly even if Atlantis is protected by IAP"
+  default     = false
+}
+
 variable "google_logging_enabled" {
   type        = bool
   description = "Enable Google Cloud Logging"


### PR DESCRIPTION
## what
* Give users the option to expose the `/healthz` endpoint from the default (non-IAP) backend

## why
* This allows users to create url-based Uptime Checks targeting `/healthz`

## references
* https://cloud.google.com/monitoring/api/resources#tag_uptime_url
* https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_uptime_check_config
