### PR TITLE
refactor!: gce-container-declaration deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_args"></a> [args](#input\_args) | Arguments to override the container image default command (CMD). | `list(string)` | `[]` | no |
+| <a name="input_autoscaling"></a> [autoscaling](#input\_autoscaling) | Allow the instance group to scale down to zero based on signals | <pre>object({<br/>    schedules = list(object({<br/>      name         = string<br/>      description  = string<br/>      schedule     = string<br/>      time_zone    = string<br/>      duration_sec = number<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_block_project_ssh_keys_enabled"></a> [block\_project\_ssh\_keys\_enabled](#input\_block\_project\_ssh\_keys\_enabled) | Blocks the use of project-wide publich SSH keys | `bool` | `false` | no |
 | <a name="input_command"></a> [command](#input\_command) | Command to override the container image ENTRYPOINT | `list(string)` | `[]` | no |
 | <a name="input_default_backend_security_policy"></a> [default\_backend\_security\_policy](#input\_default\_backend\_security\_policy) | Name of the security policy to apply to the default backend service | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This Terraform module deploys various resources to run Atlantis on Google Comput
   - [Resources](#resources)
   - [Inputs](#inputs)
   - [Outputs](#outputs)
+  - [License](#license)
 
 ## Feature highlights
 
@@ -210,9 +211,7 @@ You can check the status of the certificate in the Google Cloud Console.
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_container"></a> [container](#module\_container) | terraform-google-modules/container-vm/google | ~> 3.2 |
+No modules.
 
 ## Resources
 
@@ -242,10 +241,9 @@ You can check the status of the certificate in the Google Cloud Console.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_args"></a> [args](#input\_args) | Arguments to override the container image default command (CMD). | `list(string)` | `null` | no |
-| <a name="input_autoscaling"></a> [autoscaling](#input\_autoscaling) | Allow the instance group to scale down to zero based on signals | <pre>object({<br/>    schedules = list(object({<br/>      name         = string<br/>      description  = string<br/>      schedule     = string<br/>      time_zone    = string<br/>      duration_sec = number<br/>    }))<br/>  })</pre> | `null` | no |
+| <a name="input_args"></a> [args](#input\_args) | Arguments to override the container image default command (CMD). | `list(string)` | `[]` | no |
 | <a name="input_block_project_ssh_keys_enabled"></a> [block\_project\_ssh\_keys\_enabled](#input\_block\_project\_ssh\_keys\_enabled) | Blocks the use of project-wide publich SSH keys | `bool` | `false` | no |
-| <a name="input_command"></a> [command](#input\_command) | Command to override the container image ENTRYPOINT | `list(string)` | `null` | no |
+| <a name="input_command"></a> [command](#input\_command) | Command to override the container image ENTRYPOINT | `list(string)` | `[]` | no |
 | <a name="input_default_backend_security_policy"></a> [default\_backend\_security\_policy](#input\_default\_backend\_security\_policy) | Name of the security policy to apply to the default backend service | `string` | `null` | no |
 | <a name="input_disk_kms_key_self_link"></a> [disk\_kms\_key\_self\_link](#input\_disk\_kms\_key\_self\_link) | The self link of the encryption key that is stored in Google Cloud KMS | `string` | `null` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://` | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,11 @@ locals {
   atlantis_network_traffic_tags = ["atlantis-${random_string.random.result}"]
   atlantis_labels = merge(
     var.labels,
-    module.container.container_vm.labels,
-    { "vm" = module.container.container_vm.name },
     { "app" = "atlantis" }
   )
+  atlantis_persistent_disk_name = "atlantis-disk-0"
+  atlantis_disk_mount_path      = "/mnt/disks/gce-containers-mounts/gce-persistent-disks/${local.atlantis_persistent_disk_name}"
+  atlantis_uid                  = 100
 }
 
 resource "random_string" "random" {
@@ -40,7 +41,20 @@ data "cloudinit_config" "config" {
   base64_encode = false
 
   part {
-    filename     = "atlantis-chown-disk.service"
+    filename     = "runcmda"
+    content_type = "text/cloud-config"
+    merge_type   = "list(append)+dict(no_replace, recurse_list)+str()"
+    content = yamlencode({
+      runcmd = [
+        "systemctl daemon-reload",
+        "systemctl start --no-block atlantis-chown-disk.service",
+        "systemctl start --no-block atlantis.service"
+      ]
+    })
+  }
+
+  part {
+    filename     = "services"
     content_type = "text/cloud-config"
     content = yamlencode({
       write_files = [
@@ -51,10 +65,32 @@ data "cloudinit_config" "config" {
           content     = <<EOF
           [Unit]
           Description=Change ownership of the mount path to the Atlantis uid
-          Wants=konlet-startup.service
-          After=konlet-startup.service
+          Wants=docker.service
+          After=docker.service
           [Service]
-          ExecStart=/bin/chown 100 /mnt/disks/gce-containers-mounts/gce-persistent-disks/atlantis-disk-0
+          ExecStart=/bin/chown ${local.atlantis_uid} ${local.atlantis_disk_mount_path}
+          Restart=on-failure
+          RestartSec=30
+          StandardOutput=journal+console
+          [Install]
+          WantedBy=multi-user.target
+          EOF
+        },
+        # https://cloud.google.com/container-optimized-os/docs/how-to/create-configure-instance#use-cloud-init
+        # we are specifying `--publish 0.0.0.0` since `--network host` was binding to an ipv6 port.
+        {
+          path        = "/etc/systemd/system/atlantis.service"
+          permissions = "0644"
+          owner       = "root"
+          content     = <<EOF
+          [Unit]
+          Description=Start atlantis container
+          Wants=atlantis-chown-disk.service
+          After=atlantis-chown-disk.service
+          [Service]
+          ExecStart=/usr/bin/docker run -u ${local.atlantis_uid} --rm --publish '0.0.0.0:${local.atlantis_port}:${local.atlantis_port}' -v ${local.atlantis_disk_mount_path}:${local.atlantis_data_dir} %{for key, value in var.env_vars} -e '${key}=${value}'%{endfor} --name=atlantis ${var.image} ${join(" ", var.command)} ${join(" ", var.args)}
+          ExecStop=/usr/bin/docker stop atlantis
+          ExecStopPost=/usr/bin/docker rm atlantis
           Restart=on-failure
           RestartSec=30
           StandardOutput=journal+console
@@ -65,61 +101,6 @@ data "cloudinit_config" "config" {
       ]
     })
   }
-
-  part {
-    filename     = "runcmda"
-    content_type = "text/cloud-config"
-    merge_type   = "list(append)+dict(no_replace, recurse_list)+str()"
-    content = yamlencode({
-      runcmd = [
-        "systemctl daemon-reload",
-        "systemctl start --no-block atlantis-chown-disk.service"
-      ]
-    })
-  }
-}
-
-module "container" {
-  source         = "terraform-google-modules/container-vm/google"
-  version        = "~> 3.2"
-  cos_image_name = var.machine_image != null ? element(split("/", var.machine_image), length(split("/", var.machine_image)) - 1) : null
-
-  container = {
-    image = var.image
-    securityContext = {
-      privileged = false
-    }
-    tty = true
-    env = [for key, value in var.env_vars : {
-      name  = key
-      value = value
-    }]
-    command = var.command
-    args    = var.args
-
-    # Declare volumes to be mounted.
-    # This is similar to how docker volumes are declared.
-    volumeMounts = [
-      {
-        mountPath = local.atlantis_data_dir
-        name      = "atlantis-disk-0"
-        readOnly  = false
-      },
-    ]
-  }
-
-  volumes = [
-    {
-      name = "atlantis-disk-0"
-
-      gcePersistentDisk = {
-        pdName = "atlantis-disk-0"
-        fsType = "ext4"
-      }
-    },
-  ]
-
-  restart_policy = "Always"
 }
 
 locals {
@@ -138,7 +119,6 @@ resource "google_compute_instance_template" "default" {
   metadata_startup_script = var.startup_script
 
   metadata = merge({
-    gce-container-declaration    = module.container.metadata_value
     user-data                    = data.cloudinit_config.config.rendered
     google-logging-enabled       = var.google_logging_enabled
     google-monitoring-enabled    = var.google_monitoring_enabled
@@ -182,10 +162,24 @@ resource "google_compute_instance_template" "default" {
 
   #  Persistent disk for Atlantis
   disk {
-    device_name = "atlantis-disk-0"
-    mode        = "READ_WRITE"
-    source      = google_compute_disk.persistent.name
-    auto_delete = false
+    device_name  = local.atlantis_persistent_disk_name
+    disk_type    = var.persistent_disk_type
+    mode         = "READ_WRITE"
+    disk_size_gb = var.persistent_disk_size_gb
+    auto_delete  = false
+    labels = merge(
+      local.atlantis_labels,
+      {
+        "disk-type" = "data"
+      },
+    )
+
+    dynamic "disk_encryption_key" {
+      for_each = var.disk_kms_key_self_link != null ? [1] : []
+      content {
+        kms_key_self_link = var.disk_kms_key_self_link
+      }
+    }
   }
 
   network_interface {

--- a/variables.tf
+++ b/variables.tf
@@ -68,13 +68,13 @@ variable "image" {
 variable "command" {
   type        = list(string)
   description = "Command to override the container image ENTRYPOINT"
-  default     = null
+  default     = []
 }
 
 variable "args" {
   type        = list(string)
   description = "Arguments to override the container image default command (CMD)."
-  default     = null
+  default     = []
 }
 
 variable "env_vars" {


### PR DESCRIPTION
Due to the Compute Engine container startup agent deprecation on July 21 2025, GCP recommends now using a startup script or cloud-init to run containers in VMs.

To avoid impacting users that already have startup scripts, this commit uses cloud-init to spin up the container.

Changes:

- Remove container module
- Add service responsible for the Atlantis container
- Changed `command` and `args` default values to `[]` instead of null, since we can't iterate null values

Impact:

- `google_compute_disk.persistent will be updated in-place`
- `google_compute_instance_group_manager.default` will be updated in-place`
- `google_compute_instance_template.default must be replaced`

**Requires a couple minutes of downtime while the VM is restarted.**

Sources:

- https://cloud.google.com/compute/docs/deprecations/container-startup-agent-on-compute
- https://cloud.google.com/compute/docs/containers/migrate-containers